### PR TITLE
Merge VS-Code debug configuration and documentation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,57 +14,6 @@
             "servertype": "openocd",
             "device": "stm32f4x",
             "configFiles": ["${workspaceFolder}/stm32-vesc-openocd-vscode.cfg"]
-        },
-        {
-            "name": "VESC Debug Test",
-            "cwd": "${workspaceFolder}",
-            "type": "cppdbg",
-            "request": "launch",
-            "program": "${workspaceRoot}/build/BLDC_4_ChibiOS.elf",
-            "stopAtEntry": false,
-            "debugServerArgs": "-f ${workspaceFolder}/stm32-vesc-openocd-vscode.cfg",
-            "preLaunchTask": "upload",
-            "setupCommands": [
-                { "text": "-target-select remote localhost:3333", "description": "connect to target", "ignoreFailures": false },
-                { "text": "-file-exec-and-symbols ${workspaceRoot}/build/BLDC_4_ChibiOS.elf", "description": "load file", "ignoreFailures": false},
-                { "text": "-interpreter-exec console \"monitor endian little\"", "ignoreFailures": false },
-                { "text": "-interpreter-exec console \"monitor reset\"", "ignoreFailures": false },
-                { "text": "-interpreter-exec console \"monitor halt\"", "ignoreFailures": false },
-                { "text": "-interpreter-exec console \"monitor arm semihosting enable\"", "ignoreFailures": false },
-                { "text": "-target-download", "description": "flash target", "ignoreFailures": false }
-            ],
-            "linux": {
-                "MIMode": "gdb",
-                "miDebuggerPath": "/usr/bin/arm-none-eabi-gdb",
-                "debugServerPath": "openocd"
-            },
-            "osx": {
-                "MIMode": "gdb",
-                "miDebuggerPath": "/usr/bin/arm-none-eabi-gdb",
-                "debugServerPath": "openocd"
-            },
-            "windows": {
-
-            }
-        },
-        {
-            "name": "VESC Debug Test 2",
-            "type": "cppdbg",
-            "request": "launch",
-            "cwd": "${workspaceFolder}",
-            "program": "${workspaceRoot}/build/BLDC_4_ChibiOS.elf",
-            "stopAtEntry": true,
-            "setupCommands": [
-                {"text": "-target remote localhost:3333"},
-                {"text": "-symbol-file ${workspaceFolder}/stm32-vesc-openocd-vscode.cfg"},
-                {"text": "-monitor reset"}
-            ],
-            "linux": {
-                "MIMode": "gdb",
-                "miDebuggerPath": "/usr/bin/arm-none-eabi-gdb",
-                "debugServerPath": "openocd"
-            },
-        },
-        
+        }        
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,29 +7,64 @@
     "configurations": [
         {
             "name": "VESC Debug",
-            "cwd": "${workspaceRoot}",
-            "executable": "./build/BLDC_4_ChibiOS.elf",
-            "request": "launch",
             "type": "cortex-debug",
+            "request": "launch",
+            "cwd": "${workspaceFolder}",
+            "executable": "${workspaceRoot}/build/BLDC_4_ChibiOS.elf",
             "servertype": "openocd",
-            // "device": "STM32F405RG",
-            "configFiles": [
-                "stm32-vesc-openocd-vscode.cfg"
+            "device": "stm32f4x",
+            "configFiles": ["${workspaceFolder}/stm32-vesc-openocd-vscode.cfg"]
+        },
+        {
+            "name": "VESC Debug Test",
+            "cwd": "${workspaceFolder}",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/build/BLDC_4_ChibiOS.elf",
+            "stopAtEntry": false,
+            "debugServerArgs": "-f ${workspaceFolder}/stm32-vesc-openocd-vscode.cfg",
+            "preLaunchTask": "upload",
+            "setupCommands": [
+                { "text": "-target-select remote localhost:3333", "description": "connect to target", "ignoreFailures": false },
+                { "text": "-file-exec-and-symbols ${workspaceRoot}/build/BLDC_4_ChibiOS.elf", "description": "load file", "ignoreFailures": false},
+                { "text": "-interpreter-exec console \"monitor endian little\"", "ignoreFailures": false },
+                { "text": "-interpreter-exec console \"monitor reset\"", "ignoreFailures": false },
+                { "text": "-interpreter-exec console \"monitor halt\"", "ignoreFailures": false },
+                { "text": "-interpreter-exec console \"monitor arm semihosting enable\"", "ignoreFailures": false },
+                { "text": "-target-download", "description": "flash target", "ignoreFailures": false }
             ],
-            "preLaunchTask": "upload", // runs make upload to compile and upload latest code
             "linux": {
                 "MIMode": "gdb",
-                "MIDebuggerPath": "/usr/bin/arm-none-eabi-gdb", // Change this to the path of your gdb installation
+                "miDebuggerPath": "/usr/bin/arm-none-eabi-gdb",
                 "debugServerPath": "openocd"
             },
             "osx": {
                 "MIMode": "gdb",
-                "MIDebuggerPath": "/usr/local/bin/arm-none-eabi-gdb", // Change this to the path of your gdb installation
+                "miDebuggerPath": "/usr/bin/arm-none-eabi-gdb",
                 "debugServerPath": "openocd"
             },
             "windows": {
-                
+
             }
-        }
+        },
+        {
+            "name": "VESC Debug Test 2",
+            "type": "cppdbg",
+            "request": "launch",
+            "cwd": "${workspaceFolder}",
+            "program": "${workspaceRoot}/build/BLDC_4_ChibiOS.elf",
+            "stopAtEntry": true,
+            "setupCommands": [
+                {"text": "-target remote localhost:3333"},
+                {"text": "-symbol-file ${workspaceFolder}/stm32-vesc-openocd-vscode.cfg"},
+                {"text": "-monitor reset"}
+            ],
+            "linux": {
+                "MIMode": "gdb",
+                "miDebuggerPath": "/usr/bin/arm-none-eabi-gdb",
+                "debugServerPath": "openocd"
+            },
+        },
+        
     ]
 }

--- a/docs/on-chip_debugging.md
+++ b/docs/on-chip_debugging.md
@@ -1,0 +1,48 @@
+# How to set up On-Chip Debugging for VESC on VS-Code
+## Installation
+1. Make sure you have the packages necessary to build and develop with the STM32
+```bash
+sudo apt-get install build-essential git flex bison libgmp3-dev libmpfr-dev libncurses5-dev libmpc-dev autoconf texinfo libtool libftdi-dev libusb-1.0-0-dev zlib1g zlib1g-dev python-yaml
+```
+
+2. Install OpenOCD either using your package manager or building it from source. You can find more information here: http://openocd.org/getting-openocd/
+
+3. Install the [Cortex-Debug VS Code Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug) in your instance of Visual Studio Code.
+
+4. Add the following to your *launch.json* under *configurations* in the *.vscode* folder in your VS Code workspace:
+```json
+{
+    "name": "VESC Debug",
+    "type": "cortex-debug",
+    "request": "launch",
+    "cwd": "${workspaceFolder}",
+    "executable": "${workspaceRoot}/build/BLDC_4_ChibiOS.elf",
+    "servertype": "openocd",
+    "device": "stm32f4x",
+    "configFiles": ["${workspaceFolder}/stm32-vesc-openocd-vscode.cfg"]
+}
+```
+
+If you do not have anything additional in your *launch.json* file, your file should look like this:
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "VESC Debug",
+            "type": "cortex-debug",
+            "request": "launch",
+            "cwd": "${workspaceFolder}",
+            "executable": "${workspaceRoot}/build/BLDC_4_ChibiOS.elf",
+            "servertype": "openocd",
+            "device": "stm32f4x",
+            "configFiles": ["${workspaceFolder}/stm32-vesc-openocd-vscode.cfg"]
+        },  
+    ]
+}
+```
+## Testing
+1. To test the debugger, place a breakpoint in your code. Then, click on the *debug* tab, or hit *CTRL+ALT+D* on your keyboard.
+2. At the top of the *debug* tab, click the carrot for the dropdown menu (next to *DEBUG AND RUN*) and select the name of your configuration. The name from the example above is "VESC Debug"
+3. Ensure your VESC is properly connected to your computer using the ST-Link. If you need help doing this, please see the following link and scroll down to **Software Installation and Configuration Tool**: http://vedder.se/2015/01/vesc-open-source-esc/ 
+3. Select the green RUN button next to the dropdown menu. This should open up the debug menu and your bottom bar should turn orange (as long as you do not have a theme installed which changes this color)

--- a/stm32-vesc-openocd-vscode.cfg
+++ b/stm32-vesc-openocd-vscode.cfg
@@ -1,5 +1,5 @@
 source [find interface/stlink-v2.cfg]
-source [find target/stm32f4x_stlink.cfg]
+source [find target/stm32f4x.cfg]
 
 # use hardware reset, connect under reset
 reset_config srst_nogate


### PR DESCRIPTION
The following changes were made:
- Modify the OpenOCD config file to use non-deprecated files
- Add VS Code debug configurations using the Cortex-Debug VS-Code extension
- Add documentation for setting up on-chip debugging for VESC